### PR TITLE
fix: add inner copper layer gerber support for 4-layer boards

### DIFF
--- a/src/gerber/convert-soup-to-gerber-commands/GerberLayerName.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/GerberLayerName.ts
@@ -10,7 +10,23 @@ export type LayerToGerberCommandsMap = {
   B_SilkScreen: AnyGerberCommand[]
   B_Mask: AnyGerberCommand[]
   B_Paste: AnyGerberCommand[]
+  In1_Cu: AnyGerberCommand[]
+  In2_Cu: AnyGerberCommand[]
   Edge_Cuts: AnyGerberCommand[]
 }
+
+export const ALL_GERBER_LAYER_NAMES = [
+  "F_Cu",
+  "F_SilkScreen",
+  "F_Mask",
+  "F_Paste",
+  "B_Cu",
+  "B_SilkScreen",
+  "B_Mask",
+  "B_Paste",
+  "In1_Cu",
+  "In2_Cu",
+  "Edge_Cuts",
+] as const
 
 export type GerberLayerName = keyof LayerToGerberCommandsMap

--- a/src/gerber/convert-soup-to-gerber-commands/getCommandHeaders.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/getCommandHeaders.ts
@@ -12,6 +12,10 @@ const layerAndTypeToFileFunction = {
   "top-paste": "Paste,Top",
   "bottom-paste": "Paste,Bot",
   edgecut: "Profile,NP",
+  "inner1-copper": "Copper,L3,Inr",
+  "inner2-copper": "Copper,L4,Inr",
+  "inner3-copper": "Copper,L5,Inr",
+  "inner4-copper": "Copper,L6,Inr",
   // TODO inner layers
 }
 

--- a/src/gerber/convert-soup-to-gerber-commands/index.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/index.ts
@@ -71,6 +71,14 @@ export const convertSoupToGerberCommands = (
       layer: "bottom",
       layer_type: "paste",
     }),
+    In1_Cu: getCommandHeaders({
+      layer: "inner1",
+      layer_type: "copper",
+    }),
+    In2_Cu: getCommandHeaders({
+      layer: "inner2",
+      layer_type: "copper",
+    }),
     Edge_Cuts: getCommandHeaders({
       layer: "edgecut",
     }),
@@ -79,6 +87,8 @@ export const convertSoupToGerberCommands = (
   for (const glayer_name of [
     "F_Cu",
     "B_Cu",
+    "In1_Cu",
+    "In2_Cu",
     "F_Mask",
     "B_Mask",
     "F_Paste",


### PR DESCRIPTION
## Summary

Fixes #78 - 4-layer boards silently export as 2-layer (no In1_Cu / In2_Cu gerbers)

**Root Cause:** The gerber converter was missing support for inner copper layers (In1_Cu, In2_Cu) entirely. The `LayerToGerberCommandsMap` type and initialization code only included F_Cu (top) and B_Cu (bottom).

**Changes:**

1. Added `In1_Cu` and `In2_Cu` to `LayerToGerberCommandsMap` type
2. Added `ALL_GERBER_LAYER_NAMES` constant including inner copper layers
3. Added In1_Cu and In2_Cu gerber layer initialization
4. Included In1_Cu/In2_Cu in the aperture/macro setup loop
5. Added inner layer file functions to `getCommandHeaders` (`Copper,L3,Inr`, `Copper,L4,Inr`)


**Note:** Full inner layer element processing (traces, pads on inner layers) requires `pcb_internal_copper_layer` support in circuit-json. This fix ensures proper gerber file structure when those elements are added.

## Test plan

- [ ] Build passes
- [ ] 4-layer board exports include In1_Cu.gbr and In2_Cu.gbr
- [ ] Existing 2-layer board exports unchanged