### PR TITLE
feat: generate In1_Cu and In2_Cu gerber files for 4-layer boards

### DIFF
--- a/src/gerber/convert-soup-to-gerber-commands/GerberLayerName.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/GerberLayerName.ts
@@ -11,6 +11,7 @@ export type LayerToGerberCommandsMap = {
   B_Mask: AnyGerberCommand[]
   B_Paste: AnyGerberCommand[]
   Edge_Cuts: AnyGerberCommand[]
+  [key: string]: AnyGerberCommand[]
 }
 
 export type GerberLayerName = keyof LayerToGerberCommandsMap

--- a/src/gerber/convert-soup-to-gerber-commands/defineAperturesForLayer.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/defineAperturesForLayer.ts
@@ -25,7 +25,7 @@ export function defineAperturesForLayer({
 }: {
   glayer: AnyGerberCommand[]
   soup: AnyCircuitElement[]
-  glayer_name: GerberLayerName
+  glayer_name: string
 }) {
   const getNextApertureNumber = () => {
     const highest_aperture_number = glayer.reduce((acc, command) => {
@@ -47,10 +47,21 @@ export function defineAperturesForLayer({
   )
 
   // Add all trace width apertures
-  const traceWidths: Record<LayerRef, number[]> = getAllTraceWidths(soup)
-  for (const width of traceWidths[
-    glayer_name.startsWith("F_") ? "top" : "bottom"
-  ]) {
+  const traceWidths: Record<string, number[]> = getAllTraceWidths(soup)
+  const layerRefForGlayer = glayer_name.startsWith("F_")
+    ? "top"
+    : glayer_name.startsWith("B_")
+      ? "bottom"
+      : glayer_name.startsWith("In1_")
+        ? "inner1"
+        : glayer_name.startsWith("In2_")
+          ? "inner2"
+          : glayer_name.startsWith("In3_")
+            ? "inner3"
+            : glayer_name.startsWith("In4_")
+              ? "inner4"
+              : "top"
+  for (const width of traceWidths[layerRefForGlayer] ?? []) {
     glayer.push(
       ...gerberBuilder()
         .add("define_aperture_template", {

--- a/src/gerber/convert-soup-to-gerber-commands/getAllTraceWidths.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/getAllTraceWidths.ts
@@ -18,8 +18,16 @@ export function getAllTraceWidths(
     }
   }
 
-  return {
+  const result: Record<string, number[]> = {
     top: Array.from(widths.top || []),
     bottom: Array.from(widths.bottom || []),
-  } as any
+  }
+
+  for (const inner of ["inner1", "inner2", "inner3", "inner4"] as const) {
+    if (widths[inner]) {
+      result[inner] = Array.from(widths[inner])
+    }
+  }
+
+  return result as any
 }

--- a/src/gerber/convert-soup-to-gerber-commands/getCommandHeaders.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/getCommandHeaders.ts
@@ -2,8 +2,12 @@ import type { AnyGerberCommand } from "src/gerber/any_gerber_command"
 import { gerberBuilder } from "../gerber-builder"
 import packageJson from "../../../package.json"
 
-const layerAndTypeToFileFunction = {
+const layerAndTypeToFileFunction: Record<string, string> = {
   "top-copper": "Copper,L1,Top",
+  "inner1-copper": "Copper,L2,Inr",
+  "inner2-copper": "Copper,L3,Inr",
+  "inner3-copper": "Copper,L4,Inr",
+  "inner4-copper": "Copper,L5,Inr",
   "bottom-copper": "Copper,L2,Bot",
   "top-soldermask": "Soldermask,Top",
   "bottom-soldermask": "Soldermask,Bot",
@@ -12,7 +16,6 @@ const layerAndTypeToFileFunction = {
   "top-paste": "Paste,Top",
   "bottom-paste": "Paste,Bot",
   edgecut: "Profile,NP",
-  // TODO inner layers
 }
 
 /**

--- a/src/gerber/convert-soup-to-gerber-commands/getGerberLayerName.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/getGerberLayerName.ts
@@ -1,10 +1,14 @@
 import type { LayerRef } from "circuit-json"
 import type { GerberLayerName } from "./GerberLayerName"
 
-const layerRefToGerberPrefix = {
+const layerRefToGerberPrefix: Record<string, string> = {
   top: "F_",
   bottom: "B_",
-} as const
+  inner1: "In1_",
+  inner2: "In2_",
+  inner3: "In3_",
+  inner4: "In4_",
+}
 const layerTypeToGerberSuffix = {
   copper: "Cu",
   silkscreen: "SilkScreen",
@@ -18,5 +22,9 @@ export const getGerberLayerName = (
   layer_type: "copper" | "silkscreen" | "soldermask" | "paste",
 ): GerberLayerName => {
   if (layer_ref === "edgecut") return "Edge_Cuts"
-  return `${layerRefToGerberPrefix[layer_ref as keyof typeof layerRefToGerberPrefix]}${layerTypeToGerberSuffix[layer_type]}`
+  const prefix = layerRefToGerberPrefix[layer_ref as string]
+  if (!prefix) {
+    throw new Error(`Unknown layer ref: ${layer_ref}`)
+  }
+  return `${prefix}${layerTypeToGerberSuffix[layer_type]}` as GerberLayerName
 }

--- a/src/gerber/convert-soup-to-gerber-commands/index.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/index.ts
@@ -38,6 +38,25 @@ export const convertSoupToGerberCommands = (
 ): LayerToGerberCommandsMap => {
   opts.flip_y_axis ??= false
   const hasPanel = soup.some((e) => e.type === "pcb_panel")
+
+  // Detect which inner copper layers have traces in this design
+  const innerLayersUsed = new Set<"inner1" | "inner2" | "inner3" | "inner4">()
+  for (const element of soup) {
+    if (element.type === "pcb_trace") {
+      for (const segment of element.route) {
+        if (
+          segment.route_type === "wire" &&
+          (segment.layer === "inner1" ||
+            segment.layer === "inner2" ||
+            segment.layer === "inner3" ||
+            segment.layer === "inner4")
+        ) {
+          innerLayersUsed.add(segment.layer as any)
+        }
+      }
+    }
+  }
+
   const glayers: LayerToGerberCommandsMap = {
     F_Cu: getCommandHeaders({
       layer: "top",
@@ -76,6 +95,26 @@ export const convertSoupToGerberCommands = (
     }),
   }
 
+  // Initialize inner copper layers that are actually used
+  const innerLayerGlayerNames: Array<{
+    inner: "inner1" | "inner2" | "inner3" | "inner4"
+    glayerKey: keyof LayerToGerberCommandsMap
+  }> = [
+    { inner: "inner1", glayerKey: "In1_Cu" },
+    { inner: "inner2", glayerKey: "In2_Cu" },
+    { inner: "inner3", glayerKey: "In3_Cu" },
+    { inner: "inner4", glayerKey: "In4_Cu" },
+  ]
+
+  for (const { inner, glayerKey } of innerLayerGlayerNames) {
+    if (innerLayersUsed.has(inner)) {
+      glayers[glayerKey] = getCommandHeaders({
+        layer: inner,
+        layer_type: "copper",
+      })
+    }
+  }
+
   for (const glayer_name of [
     "F_Cu",
     "B_Cu",
@@ -93,6 +132,19 @@ export const convertSoupToGerberCommands = (
       glayer,
       glayer_name,
     })
+  }
+
+  // Initialize apertures for inner copper layers
+  for (const { glayerKey } of innerLayerGlayerNames) {
+    const glayer = glayers[glayerKey]
+    if (glayer) {
+      defineCommonMacros(glayer)
+      defineAperturesForLayer({
+        soup,
+        glayer,
+        glayer_name: glayerKey as any,
+      })
+    }
   }
 
   // Edgecuts has a single aperature
@@ -591,7 +643,13 @@ export const convertSoupToGerberCommands = (
   }
 
   // SECOND PASS: Process all other elements (traces, pads, vias, etc.)
-  for (const layer of ["top", "bottom", "edgecut"] as const) {
+  const activeInnerLayers = Array.from(innerLayersUsed)
+  for (const layer of [
+    "top",
+    ...activeInnerLayers,
+    "bottom",
+    "edgecut",
+  ] as const) {
     for (const element of soup) {
       if (element.type === "pcb_trace") {
         const { route } = element
@@ -603,17 +661,19 @@ export const convertSoupToGerberCommands = (
           if (a.route_type === "wire") {
             if (a.layer === layer) {
               const glayer = glayers[getGerberLayerName(layer, "copper")]
-              glayer.push(
-                ...gerberBuilder()
-                  .add("select_aperture", {
-                    aperture_number: findApertureNumber(glayer, {
-                      trace_width: a.width,
-                    }),
-                  })
-                  .add("move_operation", { x: a.x, y: mfy(a.y) })
-                  .add("plot_operation", { x: b.x, y: mfy(b.y) })
-                  .build(),
-              )
+              if (glayer) {
+                glayer.push(
+                  ...gerberBuilder()
+                    .add("select_aperture", {
+                      aperture_number: findApertureNumber(glayer, {
+                        trace_width: a.width,
+                      }),
+                    })
+                    .add("move_operation", { x: a.x, y: mfy(a.y) })
+                    .add("plot_operation", { x: b.x, y: mfy(b.y) })
+                    .build(),
+                )
+              }
             }
           }
         }
@@ -644,7 +704,7 @@ export const convertSoupToGerberCommands = (
         }
       } else if (
         element.type === "pcb_silkscreen_text" &&
-        layer !== "edgecut"
+        (layer === "top" || layer === "bottom")
       ) {
         renderVectorText(
           element,
@@ -652,7 +712,10 @@ export const convertSoupToGerberCommands = (
           "silkscreen",
           getApertureConfigFromPcbSilkscreenText,
         )
-      } else if (element.type === "pcb_copper_text" && layer !== "edgecut") {
+      } else if (
+        element.type === "pcb_copper_text" &&
+        (layer === "top" || layer === "bottom")
+      ) {
         renderVectorText(
           element,
           layer,

--- a/tests/gerber/generate-gerber-with-4-layer-board.test.tsx
+++ b/tests/gerber/generate-gerber-with-4-layer-board.test.tsx
@@ -1,0 +1,141 @@
+import { test, expect } from "bun:test"
+import { convertSoupToGerberCommands } from "src/gerber/convert-soup-to-gerber-commands"
+import { stringifyGerberCommands } from "src/gerber/stringify-gerber"
+
+// Test that 4-layer boards emit In1_Cu and In2_Cu gerber files
+// for traces routed on inner1 and inner2 layers
+test("4-layer board emits In1_Cu and In2_Cu gerbers for inner layer traces", () => {
+  // Minimal circuit JSON with a trace on inner1 and inner2
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "sc0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "pcb_board",
+      pcb_board_id: "board0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      num_layers: 4,
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_inner1",
+      source_trace_id: "st0",
+      route: [
+        {
+          route_type: "wire",
+          x: 0,
+          y: 0,
+          width: 0.25,
+          layer: "inner1",
+          start_pcb_port_id: "pp0",
+        },
+        {
+          route_type: "wire",
+          x: 5,
+          y: 0,
+          width: 0.25,
+          layer: "inner1",
+        },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_inner2",
+      source_trace_id: "st1",
+      route: [
+        {
+          route_type: "wire",
+          x: 0,
+          y: 2,
+          width: 0.3,
+          layer: "inner2",
+          start_pcb_port_id: "pp1",
+        },
+        {
+          route_type: "wire",
+          x: 5,
+          y: 2,
+          width: 0.3,
+          layer: "inner2",
+        },
+      ],
+    },
+  ]
+
+  const gerberCmds = convertSoupToGerberCommands(circuitJson)
+
+  // In1_Cu and In2_Cu should be present for the inner layer traces
+  expect(gerberCmds.In1_Cu).toBeDefined()
+  expect(gerberCmds.In2_Cu).toBeDefined()
+
+  // In3_Cu and In4_Cu should NOT be present (no traces on those layers)
+  expect(gerberCmds.In3_Cu).toBeUndefined()
+  expect(gerberCmds.In4_Cu).toBeUndefined()
+
+  // Standard layers should still be present
+  expect(gerberCmds.F_Cu).toBeDefined()
+  expect(gerberCmds.B_Cu).toBeDefined()
+  expect(gerberCmds.Edge_Cuts).toBeDefined()
+
+  // The In1_Cu gerber should contain a trace (wire plot operation)
+  const in1GerberStr = stringifyGerberCommands(gerberCmds.In1_Cu!)
+  expect(in1GerberStr).toContain("D01*") // plot operation (draw)
+  expect(in1GerberStr).toContain("D02*") // move operation
+
+  const in2GerberStr = stringifyGerberCommands(gerberCmds.In2_Cu!)
+  expect(in2GerberStr).toContain("D01*")
+  expect(in2GerberStr).toContain("D02*")
+
+  // In1_Cu header should identify it as an inner copper layer
+  expect(in1GerberStr).toContain("Copper,L2,Inr")
+  expect(in2GerberStr).toContain("Copper,L3,Inr")
+})
+
+// Test that 2-layer boards (the default) do NOT emit inner layer gerbers
+test("2-layer board does not emit inner copper layer gerbers", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_top",
+      source_trace_id: "st0",
+      route: [
+        {
+          route_type: "wire",
+          x: 0,
+          y: 0,
+          width: 0.25,
+          layer: "top",
+        },
+        {
+          route_type: "wire",
+          x: 5,
+          y: 0,
+          width: 0.25,
+          layer: "top",
+        },
+      ],
+    },
+  ]
+
+  const gerberCmds = convertSoupToGerberCommands(circuitJson)
+
+  // Inner layers should not be present for a 2-layer board
+  expect(gerberCmds.In1_Cu).toBeUndefined()
+  expect(gerberCmds.In2_Cu).toBeUndefined()
+
+  // Standard layers still present
+  expect(gerberCmds.F_Cu).toBeDefined()
+  expect(gerberCmds.B_Cu).toBeDefined()
+})


### PR DESCRIPTION
Closes #78\n\nFixes 4-layer boards silently exporting as 2-layer. Now generates In1_Cu and In2_Cu gerber files for inner copper layers.