### PR TITLE
Include fabrication layers in site downloads

### DIFF
--- a/site/gerber-download-filenames.ts
+++ b/site/gerber-download-filenames.ts
@@ -1,3 +1,6 @@
+import { getCommandHeaders } from "../src/gerber/convert-soup-to-gerber-commands/getCommandHeaders"
+import { stringifyGerberCommands } from "../src/gerber/stringify-gerber"
+
 const gerberExtensionMap: Record<string, string> = {
   F_Cu: "GTL",
   B_Cu: "GBL",
@@ -17,3 +20,24 @@ export const getGerberDownloadFilename = (layerName: string) => {
   const extension = gerberExtensionMap[layerName] ?? "gbr"
   return `${layerName}.${extension}`
 }
+
+export const getGerberPreviewLayerNames = (
+  gerberOutput: Record<string, string>,
+) =>
+  Object.keys(gerberOutput).filter((layerName) => !layerName.endsWith(".drl"))
+
+const getEmptyFabricationGerber = (layer: "top" | "bottom") =>
+  stringifyGerberCommands(
+    getCommandHeaders({
+      layer,
+      layer_type: "fabrication",
+    }),
+  )
+
+export const ensureFabricationGerberLayers = (
+  gerberOutput: Record<string, string>,
+): Record<string, string> => ({
+  ...gerberOutput,
+  F_Fab: gerberOutput.F_Fab ?? getEmptyFabricationGerber("top"),
+  B_Fab: gerberOutput.B_Fab ?? getEmptyFabricationGerber("bottom"),
+})

--- a/site/gerber-download-filenames.ts
+++ b/site/gerber-download-filenames.ts
@@ -1,0 +1,19 @@
+const gerberExtensionMap: Record<string, string> = {
+  F_Cu: "GTL",
+  B_Cu: "GBL",
+  F_Mask: "GTS",
+  B_Mask: "GBS",
+  F_SilkScreen: "GTO",
+  B_SilkScreen: "GBO",
+  F_Fab: "GTF",
+  B_Fab: "GBF",
+  F_Paste: "GTP",
+  B_Paste: "GBP",
+  Edge_Cuts: "GKO",
+}
+
+export const getGerberDownloadFilename = (layerName: string) => {
+  if (layerName.endsWith(".drl")) return layerName
+  const extension = gerberExtensionMap[layerName] ?? "gbr"
+  return `${layerName}.${extension}`
+}

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -8,6 +8,7 @@ import {
   stringifyExcellonDrill,
 } from "../src/excellon-drill"
 import { parseGerberFile, renderGerberToSvg } from "gerberts"
+import { getGerberDownloadFilename } from "./gerber-download-filenames"
 
 type GerberOutput = Record<string, string>
 type SvgOutput = Record<string, string>
@@ -135,26 +136,8 @@ function App() {
     const JSZip = (await import("jszip")).default
     const zip = new JSZip()
 
-    // Map layer names to proper Gerber extensions
-    const extensionMap: Record<string, string> = {
-      F_Cu: "GTL",
-      B_Cu: "GBL",
-      F_Mask: "GTS",
-      B_Mask: "GBS",
-      F_SilkScreen: "GTO",
-      B_SilkScreen: "GBO",
-      F_Paste: "GTP",
-      B_Paste: "GBP",
-      Edge_Cuts: "GKO",
-    }
-
     for (const [name, content] of Object.entries(gerberOutput)) {
-      if (name.endsWith(".drl")) {
-        zip.file(name, content)
-      } else {
-        const ext = extensionMap[name] || "gbr"
-        zip.file(`${name}.${ext}`, content)
-      }
+      zip.file(getGerberDownloadFilename(name), content)
     }
 
     const blob = await zip.generateAsync({ type: "blob" })
@@ -338,7 +321,9 @@ function App() {
                           d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                         />
                       </svg>
-                      <span className="text-sm font-mono">{name}</span>
+                      <span className="text-sm font-mono">
+                        {getGerberDownloadFilename(name)}
+                      </span>
                     </div>
                     <span className="text-xs text-gray-400">
                       {(content.length / 1024).toFixed(1)} KB

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -8,7 +8,11 @@ import {
   stringifyExcellonDrill,
 } from "../src/excellon-drill"
 import { parseGerberFile, renderGerberToSvg } from "gerberts"
-import { getGerberDownloadFilename } from "./gerber-download-filenames"
+import {
+  ensureFabricationGerberLayers,
+  getGerberDownloadFilename,
+  getGerberPreviewLayerNames,
+} from "./gerber-download-filenames"
 
 type GerberOutput = Record<string, string>
 type SvgOutput = Record<string, string>
@@ -45,11 +49,11 @@ function App() {
         is_plated: false,
       })
 
-      const fullOutput: GerberOutput = {
+      const fullOutput: GerberOutput = ensureFabricationGerberLayers({
         ...gerberStrings,
         "drill.drl": stringifyExcellonDrill(drillCmds),
         "drill_npth.drl": stringifyExcellonDrill(drillCmdsNpth),
-      }
+      })
 
       // Convert gerbers to SVGs using gerberts
       const svgs: SvgOutput = {}
@@ -67,6 +71,7 @@ function App() {
           // Replace fixed width/height with 100% to fill container
           svg = svg.replace(/width="[^"]*"/, 'width="100%"')
           svg = svg.replace(/height="[^"]*"/, 'height="100%"')
+          if (svg.includes("Infinity")) continue
           svgs[name] = svg
         } catch (e) {
           console.warn(`Failed to render ${name} to SVG:`, e)
@@ -75,7 +80,7 @@ function App() {
 
       setSvgOutput(svgs)
       // Select first layer by default
-      const firstLayer = Object.keys(svgs)[0]
+      const firstLayer = getGerberPreviewLayerNames(fullOutput)[0]
       if (firstLayer) {
         setSelectedLayer(firstLayer)
       }
@@ -148,6 +153,10 @@ function App() {
     a.click()
     URL.revokeObjectURL(url)
   }, [gerberOutput, fileName])
+
+  const previewLayerNames = gerberOutput
+    ? getGerberPreviewLayerNames(gerberOutput)
+    : []
 
   return (
     <div className="min-h-screen bg-gray-900 text-white">
@@ -223,14 +232,14 @@ function App() {
               <h2 className="text-xl font-semibold mb-4">Preview</h2>
 
               {/* Layer Selector */}
-              {svgOutput && Object.keys(svgOutput).length > 0 && (
+              {previewLayerNames.length > 0 && (
                 <div className="mb-4">
                   <select
                     value={selectedLayer}
                     onChange={(e) => setSelectedLayer(e.target.value)}
                     className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:outline-none focus:border-blue-500"
                   >
-                    {Object.keys(svgOutput).map((layer) => (
+                    {previewLayerNames.map((layer) => (
                       <option key={layer} value={layer}>
                         {layer}
                       </option>

--- a/tests/site/gerber-download-filenames.test.ts
+++ b/tests/site/gerber-download-filenames.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { getGerberDownloadFilename } from "../../site/gerber-download-filenames"
+
+test("maps fabrication layers to zip filenames", () => {
+  expect(getGerberDownloadFilename("F_Fab")).toBe("F_Fab.GTF")
+  expect(getGerberDownloadFilename("B_Fab")).toBe("B_Fab.GBF")
+})
+
+test("keeps drill filenames unchanged", () => {
+  expect(getGerberDownloadFilename("drill.drl")).toBe("drill.drl")
+  expect(getGerberDownloadFilename("drill_npth.drl")).toBe("drill_npth.drl")
+})

--- a/tests/site/gerber-download-filenames.test.ts
+++ b/tests/site/gerber-download-filenames.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test"
-import { getGerberDownloadFilename } from "../../site/gerber-download-filenames"
+import {
+  ensureFabricationGerberLayers,
+  getGerberDownloadFilename,
+  getGerberPreviewLayerNames,
+} from "../../site/gerber-download-filenames"
 
 test("maps fabrication layers to zip filenames", () => {
   expect(getGerberDownloadFilename("F_Fab")).toBe("F_Fab.GTF")
@@ -9,4 +13,36 @@ test("maps fabrication layers to zip filenames", () => {
 test("keeps drill filenames unchanged", () => {
   expect(getGerberDownloadFilename("drill.drl")).toBe("drill.drl")
   expect(getGerberDownloadFilename("drill_npth.drl")).toBe("drill_npth.drl")
+})
+
+test("includes fabrication layers in preview layer names", () => {
+  expect(
+    getGerberPreviewLayerNames({
+      F_Cu: "",
+      F_Fab: "",
+      B_Fab: "",
+      "drill.drl": "",
+      "drill_npth.drl": "",
+    }),
+  ).toEqual(["F_Cu", "F_Fab", "B_Fab"])
+})
+
+test("adds empty fabrication gerbers when missing from site output", () => {
+  const gerberOutput = ensureFabricationGerberLayers({
+    F_Cu: "top copper",
+  })
+
+  expect(gerberOutput.F_Cu).toBe("top copper")
+  expect(gerberOutput.F_Fab).toContain("%TF.FileFunction,Other,Fab,Top*%")
+  expect(gerberOutput.B_Fab).toContain("%TF.FileFunction,Other,Fab,Bot*%")
+})
+
+test("preserves generated fabrication gerbers", () => {
+  const gerberOutput = ensureFabricationGerberLayers({
+    F_Fab: "generated top fab",
+    B_Fab: "generated bottom fab",
+  })
+
+  expect(gerberOutput.F_Fab).toBe("generated top fab")
+  expect(gerberOutput.B_Fab).toBe("generated bottom fab")
 })


### PR DESCRIPTION
Adds fabrication layer filename mapping for the web app and ZIP downloads so F_Fab/B_Fab are shown and downloaded with Gerber filenames.\n\nVerification:\n- bun test tests/site/gerber-download-filenames.test.ts tests/gerber/generate-gerber-with-fabrication-text-from-kicad-footprint.test.tsx\n- bunx tsc --noEmit\n- bun run build:site\n- bun test