### PR TITLE
Add MIT LICENSE and declare license in package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 tscircuit Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "circuit-json-to-gerber",
   "version": "0.0.84",
+  "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Fixes #125.

The package is published on npm and used by the tscircuit export pipeline, but the repo had no LICENSE file and `package.json` declared no `license` field — so npm shows no license and downstream users technically have no permission to use or redistribute it.

This PR:
- adds a `LICENSE` file with the MIT text used across the tscircuit ecosystem (identical to `tscircuit/core` and `tscircuit/props`, `Copyright (c) 2024 tscircuit Inc.`)
- adds `"license": "MIT"` to `package.json` so npm picks it up on the next publish

No code changes. If a different copyright line or year is preferred, happy to adjust — the license choice is of course the maintainers' call; MIT is proposed to match the rest of the org.

---
*This contribution was authored with AI assistance (Claude), operated by Hero988.*