### PR TITLE
fix: multilayer plated hole crashes gerber export on inner layers (#127)

### DIFF
--- a/src/gerber/convert-soup-to-gerber-commands/index.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/index.ts
@@ -1278,8 +1278,12 @@ export const convertSoupToGerberCommands = (
             if (element.shape === "hole_with_polygon_pad") {
               const { pad_outline } = element
               if (!pad_outline?.length) continue
-              const soldermaskGlayer =
-                glayers[getGerberLayerName(layer, "soldermask")]
+              // Inner layers have no soldermask gerber, so only resolve the
+              // soldermask layer for outer layers. getGerberLayerName throws
+              // for an inner layer_ref with a non-copper type (#127).
+              const soldermaskGlayer = isOuterLayerRef(layer)
+                ? glayers[getGerberLayerName(layer, "soldermask")]
+                : undefined
               let points = pad_outline
               if (
                 glayer === soldermaskGlayer &&
@@ -1343,8 +1347,12 @@ export const convertSoupToGerberCommands = (
               padHeightCandidates.push(element.rect_pad_height)
             }
             const padH = Math.max(...padHeightCandidates)
-            const soldermaskGlayer =
-              glayers[getGerberLayerName(layer, "soldermask")]
+            // Inner layers have no soldermask gerber, so only resolve the
+            // soldermask layer for outer layers. getGerberLayerName throws for
+            // an inner layer_ref with a non-copper type (#127).
+            const soldermaskGlayer = isOuterLayerRef(layer)
+              ? glayers[getGerberLayerName(layer, "soldermask")]
+              : undefined
             let soldermaskMargin = 0
             if (
               glayer === soldermaskGlayer &&

--- a/tests/gerber/generate-gerber-with-multilayer-plated-hole-repro.test.ts
+++ b/tests/gerber/generate-gerber-with-multilayer-plated-hole-repro.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertSoupToGerberCommands } from "src/gerber/convert-soup-to-gerber-commands"
+import { stringifyGerberCommandLayers } from "src/gerber/stringify-gerber"
+
+// Repro for https://github.com/tscircuit/circuit-json-to-gerber/issues/127
+// A plated hole spanning the inner copper layers of a 4-layer board used to
+// crash the whole export with "Inner layer inner1 only supports copper
+// gerbers", because the plated-hole path computed the soldermask gerber layer
+// name unconditionally for every layer it drew on (including inner layers) just
+// to compare against it. Inner layers have no soldermask; the hole should emit
+// copper on inner layers and soldermask only on the outer layers.
+const circuitJson = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "pcb_board_0",
+    center: { x: 0, y: 0 },
+    width: 20,
+    height: 20,
+    num_layers: 4,
+  },
+  {
+    type: "pcb_plated_hole",
+    pcb_plated_hole_id: "multilayer_plated_hole",
+    shape: "circle",
+    outer_diameter: 1,
+    hole_diameter: 0.5,
+    x: 0,
+    y: 0,
+    layers: ["top", "bottom", "inner1", "inner2"],
+    is_covered_with_solder_mask: false,
+  },
+] as AnyCircuitElement[]
+
+test("multilayer plated hole exports without crashing on inner layers", () => {
+  const gerberOutput = stringifyGerberCommandLayers(
+    convertSoupToGerberCommands(circuitJson),
+  )
+
+  // Copper is plotted on every layer the hole spans, inner layers included.
+  expect(gerberOutput.F_Cu).toContain("X000000000Y000000000D03*")
+  expect(gerberOutput.B_Cu).toContain("X000000000Y000000000D03*")
+  expect(gerberOutput.In1_Cu).toContain("X000000000Y000000000D03*")
+  expect(gerberOutput.In2_Cu).toContain("X000000000Y000000000D03*")
+
+  // Soldermask openings exist only on the outer layers; inner layers have no
+  // soldermask gerber at all.
+  expect(gerberOutput.F_Mask).toContain("X000000000Y000000000D03*")
+  expect(gerberOutput.B_Mask).toContain("X000000000Y000000000D03*")
+  expect(gerberOutput.In1_Mask).toBeUndefined()
+  expect(gerberOutput.In2_Mask).toBeUndefined()
+})


### PR DESCRIPTION
Fixes #127.

## Problem

Exporting gerbers for any board with 3+ copper layers threw and aborted the whole export when a plated hole spans the inner copper layers (as every through-hole pad does on a 4-layer board):

```
Error: Inner layer inner1 only supports copper gerbers
```

The `pcb_plated_hole` path resolved the soldermask gerber layer name **unconditionally** for every layer it drew on — including inner layers — purely so it could compare the current `glayer` against `soldermaskGlayer`. `getGerberLayerName` throws for any `inner*` ref with a non-copper `layer_type`, so the export died at that computation before ever reaching the comparison.

## Fix

Inner layers legitimately have no soldermask, and the soldermask glayer is never added to `layersToAddTo` for inner layers (that push is already guarded by `isOuterLayerRef`), so the `glayer === soldermaskGlayer` comparison is always false on inner layers anyway. Both `soldermaskGlayer` computations (the `hole_with_polygon_pad` branch and the circle/pill/rect branch) are now guarded with `isOuterLayerRef`, so inner layers emit copper only and never resolve a soldermask layer name. Outer-layer behavior is unchanged.

## Test

Added `tests/gerber/generate-gerber-with-multilayer-plated-hole-repro.test.ts`: a 4-layer board with a plated hole on `["top", "bottom", "inner1", "inner2"]`. It throws on `main` at the exact `getGerberLayerName(layer, "soldermask")` call and now passes — copper is plotted on `F_Cu`/`B_Cu`/`In1_Cu`/`In2_Cu`, soldermask openings appear only on `F_Mask`/`B_Mask`, and no inner soldermask gerber is created.

Verification: `bun test` → 72 pass / 0 fail; `tsc --noEmit` clean; `biome format` clean on the changed files.

---
*Authored by an AI agent (autonomous contributor). The diff, the repro test, and the verification above are the substance — please review them on their merits.*
