### PR TITLE
Use SMT pad solder paste margin as Gerber fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/react-dom": "^19.1.5",
     "archiver": "^7.0.1",
     "bun-match-svg": "^0.0.13",
-    "circuit-json": "^0.0.456",
+    "circuit-json": "^0.0.463",
     "commander": "^12.1.0",
     "format-si-unit": "^0.0.7",
     "gerber-to-svg": "^4.2.8",

--- a/src/gerber/convert-soup-to-gerber-commands/defineAperturesForLayer.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/defineAperturesForLayer.ts
@@ -22,6 +22,7 @@ import { gerberBuilder } from "../gerber-builder"
 import type { GerberLayerName } from "./GerberLayerName"
 import { getAllTraceWidths } from "./getAllTraceWidths"
 import type { AnyCircuitElement } from "circuit-json"
+import { getSolderPasteFallbackFromSmtPad } from "./getSolderPasteFallbackFromSmtPad"
 
 const getLayerRefFromGerberLayerName = (
   glayer_name: GerberLayerName,
@@ -579,6 +580,7 @@ function getAllApertureTemplateConfigsForLayer({
   const configs: ApertureTemplateConfig[] = []
   const configHashMap = new Set<string>()
   const isSoldermaskLayer = glayer_name.endsWith("_Mask")
+  const isPasteLayer = glayer_name.endsWith("_Paste")
   const isCopperLayer = glayer_name.endsWith("_Cu")
   const isFabricationLayer = glayer_name.endsWith("_Fab")
 
@@ -594,7 +596,14 @@ function getAllApertureTemplateConfigsForLayer({
     if (elm.type === "pcb_smtpad") {
       if (isFabricationLayer) continue
       if (elm.layer === layer && elm.shape !== "polygon") {
-        if (isSoldermaskLayer) {
+        if (isPasteLayer) {
+          // Preserve the base pad aperture historically emitted on paste layers.
+          addConfigIfNew(getApertureConfigFromPcbSmtpad(elm))
+          const fallback = getSolderPasteFallbackFromSmtPad(elm, circuitJson)
+          if (fallback) {
+            addConfigIfNew(getApertureConfigFromPcbSmtpad(fallback))
+          }
+        } else if (isSoldermaskLayer) {
           addConfigIfNew(getApertureConfigFromPcbSmtpadSoldermask(elm))
         } else {
           addConfigIfNew(getApertureConfigFromPcbSmtpad(elm))
@@ -717,6 +726,9 @@ function getAllApertureTemplateConfigsForLayer({
     if (elm.type === "pcb_smtpad" && elm.shape === "polygon") {
       if (elm.layer !== layer) return false
       if (isCopperLayer) return true
+      if (isPasteLayer) {
+        return getSolderPasteFallbackFromSmtPad(elm, circuitJson) !== null
+      }
       return isSoldermaskLayer && elm.is_covered_with_solder_mask !== true
     }
 

--- a/src/gerber/convert-soup-to-gerber-commands/getSolderPasteFallbackFromSmtPad.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/getSolderPasteFallbackFromSmtPad.ts
@@ -1,12 +1,8 @@
 import type { AnyCircuitElement, PCBSMTPad } from "circuit-json"
 import { offsetPolygonOutline } from "./offsetPolygonOutline"
 
-export type PcbSmtPadWithSolderPasteMargin = PCBSMTPad & {
-  solderpaste_margin?: number
-}
-
 export const getSolderPasteFallbackFromSmtPad = (
-  pad: PcbSmtPadWithSolderPasteMargin,
+  pad: PCBSMTPad,
   circuitJson: AnyCircuitElement[],
 ): PCBSMTPad | null => {
   const margin = pad.solderpaste_margin

--- a/src/gerber/convert-soup-to-gerber-commands/getSolderPasteFallbackFromSmtPad.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/getSolderPasteFallbackFromSmtPad.ts
@@ -1,0 +1,55 @@
+import type { AnyCircuitElement, PCBSMTPad } from "circuit-json"
+import { offsetPolygonOutline } from "./offsetPolygonOutline"
+
+export type PcbSmtPadWithSolderPasteMargin = PCBSMTPad & {
+  solderpaste_margin?: number
+}
+
+export const getSolderPasteFallbackFromSmtPad = (
+  pad: PcbSmtPadWithSolderPasteMargin,
+  circuitJson: AnyCircuitElement[],
+): PCBSMTPad | null => {
+  const margin = pad.solderpaste_margin
+  if (typeof margin !== "number") return null
+
+  const hasExplicitSolderPaste = circuitJson.some(
+    (element) =>
+      element.type === "pcb_solder_paste" &&
+      element.pcb_smtpad_id === pad.pcb_smtpad_id,
+  )
+  if (hasExplicitSolderPaste) return null
+
+  if (pad.shape === "circle") {
+    const radius = pad.radius + margin
+    return radius > 0 ? { ...pad, radius } : null
+  }
+
+  if (pad.shape === "polygon") {
+    return {
+      ...pad,
+      points: offsetPolygonOutline(pad.points, margin),
+    }
+  }
+
+  const width = pad.width + margin * 2
+  const height = pad.height + margin * 2
+  if (width <= 0 || height <= 0) return null
+
+  if (pad.shape === "pill" || pad.shape === "rotated_pill") {
+    return { ...pad, width, height }
+  }
+
+  const cornerRadius =
+    "corner_radius" in pad && typeof pad.corner_radius === "number"
+      ? Math.max(0, Math.min(pad.corner_radius + margin, width / 2, height / 2))
+      : undefined
+
+  return {
+    ...pad,
+    width,
+    height,
+    ...(typeof cornerRadius === "number"
+      ? { corner_radius: cornerRadius }
+      : {}),
+  }
+}

--- a/src/gerber/convert-soup-to-gerber-commands/index.ts
+++ b/src/gerber/convert-soup-to-gerber-commands/index.ts
@@ -66,6 +66,7 @@ import {
   getSolidCutoutOutlinePolygon,
 } from "../utils/boardCutoutGeometry"
 import { emitCutoutEdgeCuts } from "../utils/emitCutoutEdgeCuts"
+import { getSolderPasteFallbackFromSmtPad } from "./getSolderPasteFallbackFromSmtPad"
 
 type Point = { x: number; y: number }
 
@@ -1117,6 +1118,10 @@ export const convertSoupToGerberCommands = (
         )
       } else if (element.type === "pcb_smtpad" && element.shape !== "polygon") {
         if (element.layer === layer && isOuterLayerRef(layer)) {
+          const solderPasteFallback = getSolderPasteFallbackFromSmtPad(
+            element,
+            circuitJson,
+          )
           if (element.shape === "pill" || element.shape === "rotated_pill") {
             const soldermaskMargin =
               typeof element.soldermask_margin === "number"
@@ -1146,6 +1151,20 @@ export const convertSoupToGerberCommands = (
               rotationDegrees: rotation,
             })
 
+            if (
+              solderPasteFallback?.shape === "pill" ||
+              solderPasteFallback?.shape === "rotated_pill"
+            ) {
+              renderPillFlash({
+                glayer: glayers[getGerberLayerName(layer, "paste")],
+                x: solderPasteFallback.x,
+                y: solderPasteFallback.y,
+                width: solderPasteFallback.width,
+                height: solderPasteFallback.height,
+                rotationDegrees: rotation,
+              })
+            }
+
             continue
           }
 
@@ -1155,7 +1174,7 @@ export const convertSoupToGerberCommands = (
               ? element.ccw_rotation
               : 0
 
-          for (const { glayer, apertureConfig } of [
+          const layersAndApertures = [
             {
               glayer: glayers[getGerberLayerName(layer, "copper")],
               apertureConfig: getApertureConfigFromPcbSmtpad(element),
@@ -1164,7 +1183,17 @@ export const convertSoupToGerberCommands = (
               glayer: glayers[getGerberLayerName(layer, "soldermask")],
               apertureConfig: getApertureConfigFromPcbSmtpadSoldermask(element),
             },
-          ]) {
+          ]
+
+          if (solderPasteFallback) {
+            layersAndApertures.push({
+              glayer: glayers[getGerberLayerName(layer, "paste")],
+              apertureConfig:
+                getApertureConfigFromPcbSmtpad(solderPasteFallback),
+            })
+          }
+
+          for (const { glayer, apertureConfig } of layersAndApertures) {
             const apertureNumber = findApertureNumber(glayer, apertureConfig)
             const gb = gerberBuilder().add("select_aperture", {
               aperture_number: apertureNumber,
@@ -1189,17 +1218,31 @@ export const convertSoupToGerberCommands = (
       } else if (element.type === "pcb_smtpad" && element.shape === "polygon") {
         if (element.layer === layer && isOuterLayerRef(layer)) {
           const layers_to_add_to = [
-            glayers[getGerberLayerName(layer, "copper")],
+            {
+              glayer: glayers[getGerberLayerName(layer, "copper")],
+              points: element.points,
+            },
           ]
 
           if (element.is_covered_with_solder_mask !== true) {
-            layers_to_add_to.push(
-              glayers[getGerberLayerName(layer, "soldermask")],
-            )
+            layers_to_add_to.push({
+              glayer: glayers[getGerberLayerName(layer, "soldermask")],
+              points: element.points,
+            })
           }
 
-          for (const glayer of layers_to_add_to) {
-            const { points } = element
+          const solderPasteFallback = getSolderPasteFallbackFromSmtPad(
+            element,
+            circuitJson,
+          )
+          if (solderPasteFallback?.shape === "polygon") {
+            layers_to_add_to.push({
+              glayer: glayers[getGerberLayerName(layer, "paste")],
+              points: solderPasteFallback.points,
+            })
+          }
+
+          for (const { glayer, points } of layers_to_add_to) {
             if (!points) continue
             addClosedRegionFromPoints({
               target: glayer,

--- a/tests/gerber/generate-gerber-with-smtpad-solderpaste-margin.test.ts
+++ b/tests/gerber/generate-gerber-with-smtpad-solderpaste-margin.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertSoupToGerberCommands } from "src/gerber/convert-soup-to-gerber-commands"
+import { stringifyGerberCommandLayers } from "src/gerber/stringify-gerber"
+
+test("smtpad solderpaste margin creates paste when explicit paste is absent", () => {
+  const circuitJson = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 8,
+      height: 6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "fallback_pad",
+      shape: "rect",
+      layer: "top",
+      x: -2,
+      y: 0,
+      width: 2,
+      height: 1,
+      solderpaste_margin: -0.1,
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "explicit_pad",
+      shape: "rect",
+      layer: "top",
+      x: 2,
+      y: 0,
+      width: 2,
+      height: 1,
+      solderpaste_margin: -0.2,
+    },
+    {
+      type: "pcb_solder_paste",
+      pcb_solder_paste_id: "explicit_paste",
+      pcb_smtpad_id: "explicit_pad",
+      shape: "rect",
+      layer: "top",
+      x: 2,
+      y: 0,
+      width: 0.7,
+      height: 0.3,
+    },
+  ] as AnyCircuitElement[]
+
+  const gerberOutput = stringifyGerberCommandLayers(
+    convertSoupToGerberCommands(circuitJson),
+  )
+
+  expect(gerberOutput.F_Paste).toContain("R,1.800000X0.800000")
+  expect(gerberOutput.F_Paste).toContain("X-02000000Y000000000D03*")
+  expect(gerberOutput.F_Paste).toContain("R,0.700000X0.300000")
+  expect(gerberOutput.F_Paste).toContain("X002000000Y000000000D03*")
+  expect(gerberOutput.F_Paste).not.toContain("R,1.600000X0.600000")
+})
+
+test("polygon smtpad solderpaste margin creates an offset paste region", () => {
+  const circuitJson = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 8,
+      height: 6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "polygon_pad",
+      shape: "polygon",
+      layer: "top",
+      points: [
+        { x: -1, y: -1 },
+        { x: 1, y: -1 },
+        { x: 1, y: 1 },
+        { x: -1, y: 1 },
+      ],
+      solderpaste_margin: -0.2,
+    },
+  ] as AnyCircuitElement[]
+
+  const gerberOutput = stringifyGerberCommandLayers(
+    convertSoupToGerberCommands(circuitJson),
+  )
+
+  expect(gerberOutput.F_Paste).toContain("G36*")
+  expect(gerberOutput.F_Paste).toContain("X-00800000Y-00800000D02*")
+  expect(gerberOutput.F_Paste).toContain("X000800000Y000800000D01*")
+})


### PR DESCRIPTION
## Summary

- synthesize F/B.Paste geometry from `pcb_smtpad.solderpaste_margin` when linked `pcb_solder_paste` is absent
- support circle, rect, rotated rect, pill, rotated pill, and polygon pads
- give linked explicit paste precedence over the fallback
- consume the released `PCBSMTPad.solderpaste_margin` type directly

Uses `circuit-json@^0.0.463`; the schema landed in tscircuit/circuit-json#682.

## Testing

- `bun test` (74 pass, 0 fail)
- `bunx tsc --noEmit`
- `bun run build`